### PR TITLE
Add instructions on installing dependencies for tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,1 +1,12 @@
 Please refer to https://intelowlproject.github.io/docs/IntelOwl/contribute/
+
+## Running tests locally
+
+Install the required packages before executing the test suite:
+
+```bash
+pip install -r requirements/project-requirements.txt -r requirements/test-requirements.txt
+```
+
+The tests depend on Django and other libraries from these files. Missing them
+will often result in `ModuleNotFoundError` issues.

--- a/README.md
+++ b/README.md
@@ -126,3 +126,15 @@ Feel free to contact the main developers at any time on Twitter:
 - [Simone Berni](https://twitter.com/0ssig3no): Backend Maintainer
 - [Federico Gibertoni](https://x.com/fgibertoni1): Maintainer and Community Assistant
 - [Eshaan Bansal](https://twitter.com/eshaan7_): Key Contributor
+
+## Running the tests
+
+To execute the backend tests you need the dependencies used by the project and
+the additional packages required for the test suite. Install them with:
+
+```bash
+pip install -r requirements/project-requirements.txt -r requirements/test-requirements.txt
+```
+
+The tests rely on Django and other libraries provided in these files. Skipping
+this step will usually lead to `ModuleNotFoundError` and other import issues.


### PR DESCRIPTION
## Summary
- document how to install project and test requirements before running tests
- clarify test setup in CONTRIBUTING guide

## Testing
- `python manage.py test --keepdb tests` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_688b2b4379988326829103bf41ec911a